### PR TITLE
Update guacamole-lite to 07.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cloudcmd": "^15.9.6",
     "ejs": "^3.1.6",
     "express": "^4.17.1",
-    "guacamole-lite": "0.6.3",
+    "guacamole-lite": "0.7.0",
     "node-linux-pam": "0.1.0"
   }
 }


### PR DESCRIPTION
bump guacamole-lite to version 0.7.0. This is to fix a critical vulnerability in 0.6.3. Version 0.6.3 depends on version 0.4.2 of deep-extend that contains the vulnerability CVE-2018-3750.

Lightly tested in rebuilding a fedora rdesktop-web and then a fedora webtop using that as the base. So far things seem fine.